### PR TITLE
User's Orders Page

### DIFF
--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,33 +1,36 @@
 'use client';
 
 import { OrderDetails } from '@/src/components/OrderDetails';
-import largeData from '@/src/mock/large/orders.json';
-import smallData from '@/src/mock/small/orders.json';
 import { useEffect, useState } from 'react';
-import { Item } from '@/src/type/orders';
+import UsersList from '@/src/utils/orders/users';
+import OrdersList from '@/src/utils/orders/orders';
 
 const userOrders = ({ params }: { params: { userId: string } }) => {
 
-  const [orderedItemsList, setOrderedItemsList] = useState([] as Item[]);
-  const [totalExpense, setTotalExpense] = useState();
+  const [orderedItemsList, setOrderedItemsList] = useState<any>([]);
+  const [totalExpense, setTotalExpense] = useState(0);
+  const [userName, setUserName] = useState("");
   const [loader, setLoader] = useState(true);
+  const userData = UsersList();
+  const orderData = OrdersList();
 
   useEffect(() => {
-    const data: any = JSON.parse(JSON.stringify(largeData)).concat(JSON.parse(JSON.stringify(smallData)));
-    const orders = data.filter((item: any) => item.user === params.userId);
+    const orders = orderData.filter(item => item.user === params.userId);
+    const filteredUser:any = userData.find(user => user.id === params.userId);
     const orderedItems = orders.map((order: any) => {
       return order.items;
     }).flat();
-    const TotalExpenditure = orders.reduce((sum: any, order: any) => sum + order.total, 0);
+    const totalExpenditure = orders.reduce((sum: any, order: any) => sum + order.total, 0);
     setOrderedItemsList(orderedItems);
-    setTotalExpense(TotalExpenditure);
+    setTotalExpense(totalExpenditure);
+    filteredUser && setUserName(filteredUser.firstName + " " + filteredUser.lastName);
     setLoader(false);
   }, [params.userId]);
 
 
   return (
     <div className='flex min-h-screen flex-col p-8 item-center'>
-      <h1 className='text-2xl font-semibold items-center'>Order Details</h1>
+      <h1 className='text-2xl font-semibold items-center'>Order Details - {userName}</h1>
       {loader && <p>Loading Orders..Please wait!</p>}
       {
         !loader && orderedItemsList.length === 0 ? <p>No Orders Yet!</p>
@@ -35,9 +38,12 @@ const userOrders = ({ params }: { params: { userId: string } }) => {
           !loader &&
           <>
             <div>
-            <div className='text-right'>
-              Order Total: {totalExpense}
-            </div>
+              <div className='flex flex-1 flex-row justify-around'>
+                <h2 className="text-right flex flex-1 flex-col p-4" style={{ paddingLeft: "10%" }}>Order Total</h2>
+                <div className='text-right flex flex-1 flex-col font-semibold'>
+                  <p className='font-semibold'>Total Spent: {totalExpense}</p>
+                </div>
+              </div>
               <h3 className={`mb-3 text-xl `}>
                 {
                   orderedItemsList.map((item: any) => {

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { OrderDetails } from '@/src/components/OrderDetails';
+import largeData from '@/src/mock/large/orders.json';
+import smallData from '@/src/mock/small/orders.json';
+import { useEffect, useState } from 'react';
+import { Item } from '@/src/type/orders';
+
+const userOrders = ({ params }: { params: { userId: string } }) => {
+
+  const [orderedItemsList, setOrderedItemsList] = useState([] as Item[]);
+  const [totalExpense, setTotalExpense] = useState();
+  const [loader, setLoader] = useState(true);
+
+  useEffect(() => {
+    const data: any = JSON.parse(JSON.stringify(largeData)).concat(JSON.parse(JSON.stringify(smallData)));
+    const orders = data.filter((item: any) => item.user === params.userId);
+    const orderedItems = orders.map((order: any) => {
+      return order.items;
+    }).flat();
+    const TotalExpenditure = orders.reduce((sum: any, order: any) => sum + order.total, 0);
+    setOrderedItemsList(orderedItems);
+    setTotalExpense(TotalExpenditure);
+    setLoader(false);
+  }, [params.userId]);
+
+
+  return (
+    <div className='flex min-h-screen flex-col p-8 item-center'>
+      <h1 className='text-2xl font-semibold items-center'>Order Details</h1>
+      {loader && <p>Loading Orders..Please wait!</p>}
+      {
+        !loader && orderedItemsList.length === 0 ? <p>No Orders Yet!</p>
+          :
+          !loader &&
+          <>
+            <div>
+            <div className='text-right'>
+              Order Total: {totalExpense}
+            </div>
+              <h3 className={`mb-3 text-xl `}>
+                {
+                  orderedItemsList.map((item: any) => {
+                    return <OrderDetails data={item} />
+                  })
+                }
+              </h3>
+            </div>
+          </>
+      }
+    </div>
+  );
+};
+
+export default userOrders;

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,18 +1,17 @@
 'use client';
-import largeData from '@/src/mock/large/users.json';
-import smallData from '@/src/mock/small/users.json';
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import UsersList from '@/src/utils/orders/users';
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 40;
 
 export default function Users() {
   const [currentPage, setCurrentPage] = useState(1);
-  const data = [...largeData, ...smallData];
+  const userData = UsersList();
   const startIndex = (currentPage - 1) * PAGE_SIZE;
   const endIndex = startIndex + PAGE_SIZE;
-  const usersData = data.slice(startIndex, endIndex);
-  const totalPages = Math.ceil(data.length / PAGE_SIZE);
+  const usersData = userData.slice(startIndex, endIndex);
+  const totalPages = Math.ceil(userData.length / PAGE_SIZE);
 
   const nextPage = () => {
     setCurrentPage(currentPage + 1);
@@ -30,12 +29,11 @@ export default function Users() {
     <main className='flex min-h-screen flex-col'>
       <div
         style={{
-          textAlign: 'center',
+          textAlign: 'left',
           fontSize: '1.5rem',
           fontWeight: 'bold',
-          marginBottom: '20px',
         }}
-        className='items-center'
+        className='items-left p-4'
       >
         Users
       </div>
@@ -45,12 +43,12 @@ export default function Users() {
           color: '#777',
           marginBottom: '10px',
         }}
-        className='items-left p-8'
+        className='items-left p-4'
       >
-         Select any user to get the corresponding order details
+        Select any user to get the corresponding order details
       </div>
       <div className='z-10 max-w-5xl w-full font-mono text-sm lg:flex items-center p-8'>
-        <div className='grid lg:max-w-5xl lg:w-full lg:grid-cols-3 items-center'>
+        <div className='grid lg:max-w-5xl lg:w-full lg:grid-cols-4 items-center'>
           {usersData.map((user) => (
             <div
               key={user.id}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+import largeData from '@/src/mock/large/users.json';
+import smallData from '@/src/mock/small/users.json';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const PAGE_SIZE = 30;
+
+export default function Users() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const data = [...largeData, ...smallData];
+  const startIndex = (currentPage - 1) * PAGE_SIZE;
+  const endIndex = startIndex + PAGE_SIZE;
+  const usersData = data.slice(startIndex, endIndex);
+  const totalPages = Math.ceil(data.length / PAGE_SIZE);
+
+  const nextPage = () => {
+    setCurrentPage(currentPage + 1);
+  };
+
+  const prevPage = () => {
+    setCurrentPage(currentPage - 1);
+  };
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [currentPage]);
+
+  return (
+    <main className='flex min-h-screen flex-col'>
+      <div
+        style={{
+          textAlign: 'center',
+          fontSize: '1.5rem',
+          fontWeight: 'bold',
+          marginBottom: '20px',
+        }}
+        className='items-center'
+      >
+        Users
+      </div>
+      <div
+        style={{
+          fontSize: '1.2rem',
+          color: '#777',
+          marginBottom: '10px',
+        }}
+        className='items-left p-8'
+      >
+         Select any user to get the corresponding order details
+      </div>
+      <div className='z-10 max-w-5xl w-full font-mono text-sm lg:flex items-center p-8'>
+        <div className='grid lg:max-w-5xl lg:w-full lg:grid-cols-3 items-center'>
+          {usersData.map((user) => (
+            <div
+              key={user.id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '10px',
+              }}
+            >
+              <Link href={`/users/${user.id}`}>
+                <ul>
+                  <li>
+                    <p style={{ fontSize: '1.2rem', flexGrow: '1' }}>{user.firstName} {user.lastName}</p>
+                  </li>
+                </ul>
+
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className='flex justify-around w-full border-t-2 pt-4'>
+        <button onClick={prevPage} disabled={currentPage === 1}>
+          Previous
+        </button>
+        <span>
+          Page {currentPage} of {totalPages}
+        </span>
+        <button onClick={nextPage} disabled={currentPage === totalPages}>
+          Next
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/docs/frontend/user-specifc-orders.md
+++ b/docs/frontend/user-specifc-orders.md
@@ -1,0 +1,30 @@
+# Frontend
+
+Documentation on changes added for user specific orders page.
+
+# Users Listing Page(`/users`)
+
+Navigate to `/users`  see the list of users available.
+
+- Displaying All Users from Mock Data:
+  Implemented a feature that enables the display of all users available in the mock data. Users can now easily selct any user from the list.
+
+- Pagination for Improved Navigation:
+  To enhance user experience, introduced pagination functionality similar to products page. Users can now navigate through the users list more efficiently by moving between different pages, allowing for smoother and more organized browsing.
+
+# User Specific Order Details Single Page(`/users/[userId]`)
+
+- Single Page for complete list of Order Details by a specific user:
+  Introduced a feature that offers all the order details associated with a user. On selection of any user from the previous page list, the user is taken to a new page where all the orders asscciated with the user will be listed. Specifications including order id, order name, Quantity ordered and Price is displayed. An extra column with the total price for each order is also shown for smooth experience of total calculation.
+
+  The total expense by the user on all orders is also displayed on the top.
+  To take in consideration of large amount of data(if there are), a loader message is added till the page gets populated with all the order details for a user.
+
+  Navigate to `/users/[userId]` with specific user ids to see the order details.
+
+## Folder Structure
+
+- `app/users/page.tsx` - Users Main Page
+- `app/users/[userId]/page.tsx` - Page for the order Details of a user including total expense
+- `src/components/OrderDetails.tsx` - component which shows the specific order details including    price, Quantity, ID and name
+- `src\type\orders\index.ts` - data types are addede here

--- a/docs/frontend/user-specifc-orders.md
+++ b/docs/frontend/user-specifc-orders.md
@@ -15,7 +15,7 @@ Navigate to `/users`  see the list of users available.
 # User Specific Order Details Single Page(`/users/[userId]`)
 
 - Single Page for complete list of Order Details by a specific user:
-  Introduced a feature that offers all the order details associated with a user. On selection of any user from the previous page list, the user is taken to a new page where all the orders asscciated with the user will be listed. Specifications including order id, order name, Quantity ordered and Price is displayed. An extra column with the total price for each order is also shown for smooth experience of total calculation.
+  Introduced a feature that offers all the order details associated with a user. On selection of any user from the previous page list, the user is taken to a new page where all the orders asscciated with the user will be listed. Specifications including order id, order name, Quantity ordered and Price is displayed. An extra column with the total price for each order is also shown for smooth experience of total calculation. If there are no orders done by selected user, an appropriate message is shown to indicate no orders.
 
   The total expense by the user on all orders is also displayed on the top.
   To take in consideration of large amount of data(if there are), a loader message is added till the page gets populated with all the order details for a user.

--- a/src/components/OrderDetails.tsx
+++ b/src/components/OrderDetails.tsx
@@ -1,24 +1,24 @@
 import { OrderProps } from '@/src/type/orders';
 
-export const OrderDetails = ({data}:OrderProps) => {
+export const OrderDetails = ({ data }: OrderProps) => {
   const { name, price, count, id } = data;
-  
+
   return (
     <div className='rounded-3xl p-6 bg-black-100 border border-black-100 flex flex-col md:flex-row md:items-center gap-5 transition-all duration-500 hover:border-black-400'>
       <div className='grid grid-cols-2 md:grid-cols-2 w-full gap-3 md:gap-8 grid-flow-col'>
-      
+
         <div className='flex flex-1 flex-row justify-around'>
-      <div className='flex flex-1 flex-col '>
-          <h2 className='text-black mb-3' style={{fontSize:"1rem"}}>Order ID: {id}</h2>
-          <p style={{ fontSize: '1rem'}}>Name: {name}</p>
-          <p style={{ fontSize: '1rem'}}>Price: {price}</p>
-          <p style={{ fontSize: '1rem'}}>Quantity Ordered: {count}</p>
-        </div> 
-    
-      <div className='flex flex-1 flex-col'>
-      <p style={{ fontSize: '1rem' }}> Total Price:{count*price}</p>
-      </div>
-    </div>
+          <div className='flex flex-1 flex-col '>
+            <h2 className='text-black mb-3' style={{ fontSize: "1rem" }}>Order ID: {id}</h2>
+            <p style={{ fontSize: '1rem' }}>Name: {name}</p>
+            <p style={{ fontSize: '1rem' }}>Price: {price}</p>
+            <p style={{ fontSize: '1rem' }}>Quantity Ordered: {count}</p>
+          </div>
+
+          <div className='flex flex-1 flex-col'>
+            <p style={{ fontSize: '1rem' }}> {count * price}</p>
+          </div>
+        </div>
       </div>
 
     </div>

--- a/src/components/OrderDetails.tsx
+++ b/src/components/OrderDetails.tsx
@@ -1,0 +1,26 @@
+import { OrderProps } from '@/src/type/orders';
+
+export const OrderDetails = ({data}:OrderProps) => {
+  const { name, price, count, id } = data;
+  
+  return (
+    <div className='rounded-3xl p-6 bg-black-100 border border-black-100 flex flex-col md:flex-row md:items-center gap-5 transition-all duration-500 hover:border-black-400'>
+      <div className='grid grid-cols-2 md:grid-cols-2 w-full gap-3 md:gap-8 grid-flow-col'>
+      
+        <div className='flex flex-1 flex-row justify-around'>
+      <div className='flex flex-1 flex-col '>
+          <h2 className='text-black mb-3' style={{fontSize:"1rem"}}>Order ID: {id}</h2>
+          <p style={{ fontSize: '1rem'}}>Name: {name}</p>
+          <p style={{ fontSize: '1rem'}}>Price: {price}</p>
+          <p style={{ fontSize: '1rem'}}>Quantity Ordered: {count}</p>
+        </div> 
+    
+      <div className='flex flex-1 flex-col'>
+      <p style={{ fontSize: '1rem' }}> Total Price:{count*price}</p>
+      </div>
+    </div>
+      </div>
+
+    </div>
+  );
+};

--- a/src/type/orders/index.ts
+++ b/src/type/orders/index.ts
@@ -11,3 +11,8 @@ export type Order = {
   total: number;
   time: Date;
 };
+
+export type OrderProps = {
+  data: Item;
+};
+

--- a/src/utils/orders/orders.tsx
+++ b/src/utils/orders/orders.tsx
@@ -1,0 +1,7 @@
+import orderData from '@/src/mock/small/orders.json';
+
+const OrdersList = () => {
+  return orderData;
+}
+
+export default OrdersList;

--- a/src/utils/orders/users.tsx
+++ b/src/utils/orders/users.tsx
@@ -1,0 +1,7 @@
+import userData from '@/src/mock/small/users.json';
+
+const UsersList = () => {
+  return userData;
+}
+
+export default UsersList;


### PR DESCRIPTION
Description

Added a users listing page where all the users from the data are displayed. Add another page to be navigated to on click of each user from the previous page and it will list down all the orders associated with the selected user. Can directly also navigate to the user's order details with user id. The order details page will show the total order amount by the user as well.
<img width="941" alt="image" src="https://github.com/jhanke00/next-product-site/assets/72981022/3fce7cc7-ba26-4ed8-b569-17709fe01ba0">

<img width="871" alt="image" src="https://github.com/jhanke00/next-product-site/assets/72981022/e3aa4c08-1a9c-4ade-a893-2eaf6793fda8">

Issue Reference
Issue Link - [[]([https://github.com/jhanke00/next-product-site/issues/16])](https://github.com/jhanke00/next-product-site/issues/16)

 Change Status
For this PR, completed the functionality to display the orders associated with any user in a page along with total expense. Minimal styles are only used as of now with combination of tailwind css and inline styling.

 Checklist

- All necessary files and changes are made.
-  Documentation added to `/docs/frontend/user-specific-orders.md`.
- [Appropriate labels are added (`frontend`)
[](url)