### PR TITLE
fix: add import alias support to storybook config

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/nextjs';
+import path from 'node:path';
 
 const config: StorybookConfig = {
   stories: ['../**/*.mdx', '../**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -20,6 +21,13 @@ const config: StorybookConfig = {
       test: /\.scss$/,
       use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
     });
+
+    if (config?.resolve?.alias) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@/src': path.resolve(__dirname, '../src'),
+      };
+    }
 
     return config;
   },


### PR DESCRIPTION
## Description

Add alias configuration to storybook webpack setup

## Issue Reference

[Issue 78](https://github.com/jhanke00/next-product-site/issues/78)

## Change Status

All necessary changes were made

## Checklist

- [X] All necessary files and changes are made.
- [X] Documentation added to `/docs`.
- [X] Appropriate labels are added (`frontend`, `backend`, `devops`, `infrastructure`).
