### PR TITLE
feat: :sparkles: Add DevOps label check workflow

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,28 @@
+name: PR Label Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    branches: [main]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate required labels
+        run: |
+          REQUIRED_LABELS=("Feature request" "Infrastructure" "Backend" "Frontend" "DevOps")
+          LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
+
+          for label in "${REQUIRED_LABELS[@]}"; do
+            if echo "$LABELS" | grep -qw "$label"; then
+              echo "Required label '$label' is present."
+              exit 0
+            fi
+          done
+
+          echo "Error: None of the required labels are present."
+          exit 1

--- a/docs/devops/index.md
+++ b/docs/devops/index.md
@@ -1,3 +1,25 @@
 # DevOps
 
 Documentation on any DevOps changes made.
+
+## DevOps Label Check Workflow
+
+### Overview
+
+This workflow verifies that a pull request (PR) includes at least one of the required labels.
+
+### Implementation
+
+- **Trigger**: The workflow runs on `pull_request` events, including when a PR is opened, synchronized, or labeled, specifically on the `main` branch.
+
+- **Steps**:
+  1. **Checkout Code**: Retrieves the code from the repository to perform checks.
+  2. **Validate Required Labels**:
+     - Extracts the labels from the PR.
+     - Checks if any of the following required labels are present: `Feature request`, `Infrastructure`, `Backend`, `Frontend`, `DevOps`.
+     - If a required label is found, the workflow passes.
+     - If none of the required labels are present, the workflow fails with an error message.
+
+### Purpose
+
+Ensures that PRs contain relevant labels to maintain proper categorization and workflow management.


### PR DESCRIPTION
## Description

- Added a GitHub Actions workflow to enforce that pull requests include at least one of the following labels: "Feature request", "Infrastructure", "Backend", "Frontend", "DevOps".
- The workflow triggers on PR events (`opened`, `synchronize`, `labeled`) for the `main` branch.
- The workflow will fail if none of the required labels are present, ensuring proper categorization of PRs.

## Issue Reference

[PR Label Check](https://github.com/jhanke00/next-product-site/issues/18)

## Change Status

- Implemented label check workflow.
- No major blockers encountered; workflow tested and verified.

## Checklist

- [x] All necessary files and changes are included.
- [x] Documentation has been updated.
- [ ] Appropriate labels have been added (`frontend`, `backend`, `devops`, `infrastructure`).
