### PR TITLE
Fix/78 adjusting storybook start error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-product-site",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@components/*": ["./src/components/*"],


### PR DESCRIPTION
## Description

Just fixed the Storybook error. It was only a configuration in (tsconfig.json). Storybook wasn't able to find the mocked data because of the alias (@), so it was necessary to configure it.

## Issue Reference

Issues: [78](https://github.com/jhanke00/next-product-site/issues/78), [73](https://github.com/jhanke00/next-product-site/issues/73)

## Change Status

I didn't faced any block.

## Checklist

- [X] All necessary files and changes are made.
- [ ] Documentation added to `/docs`.
- [X] Appropriate labels are added (`frontend`, `backend`, `devops`, `infrastructure`).
