### PR TITLE
fix: Fix storybook command error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@components/*": ["./src/components/*"],


### PR DESCRIPTION
## Description

Adds baseUrl property to ts config, this makes storybook able to find the alias (@).

## Issue Reference

Solves the issues: [78](https://github.com/jhanke00/next-product-site/issues/78) and [73](https://github.com/jhanke00/next-product-site/issues/73).

## Change Status

No blocks found.

## Checklist

- [x] All necessary files and changes are made.
- [x] Appropriate labels are added (`frontend`, `backend`, `devops`, `infrastructure`).
